### PR TITLE
feat: Increase default page size for pickups to 1000.

### DIFF
--- a/src/controllers/pickupController.js
+++ b/src/controllers/pickupController.js
@@ -1,7 +1,7 @@
 import { prisma } from '../database.js';
 import { logger } from '../utils/logger.js';
 
-const DEFAULT_PAGE_SIZE = 10;
+const DEFAULT_PAGE_SIZE = 1000;
 const DEFAULT_PAGE = 1;
 
 const PickupStatus = {


### PR DESCRIPTION
Updated the DEFAULT_PAGE_SIZE constant in pickupController.js to handle up to 1000 items per page instead of 10. This change is intended to improve data retrieval efficiency for larger datasets.